### PR TITLE
Improve readability

### DIFF
--- a/roles/rss2mastodon/files/requirements.txt
+++ b/roles/rss2mastodon/files/requirements.txt
@@ -1,2 +1,2 @@
-feed2toot
+feed2toot>=0.14
 

--- a/roles/rss2mastodon/templates/feed2toot.ini
+++ b/roles/rss2mastodon/templates/feed2toot.ini
@@ -17,7 +17,7 @@ lock_timeout=3600
 [rss]
 uri={{feed_url}}
 ; uri_list=/etc/feed2toot//rsslist.txt
-toot={title:.50}\n{summary:.200}\n{link} #ccc
+toot={title:.120}\n\n{summary:.200}\n{link} #ccc
 ; toot_max_len=125
 ; title_pattern=Open Source
 ; title_pattern_case_sensitive=true


### PR DESCRIPTION
Fix feed2toot to >=0.14 for newline character
Shorten title to 120 characters and description to 200. This works pretty well with the current feed.
I also added an additional line to the title to separate it from the desc.